### PR TITLE
Add new option `origin.server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,25 @@ Content-Length: 83
 }
 ```
 
+### Server origin
+
+If your same-origin requests contain an unnecessary `Origin` header, they might get blocked in case the server origin is not among the allowed origins already. In this case you can use the optional `origin.server` parameter to specify the origin of the server.
+
+``` php
+$app->add(new Tuupola\Middleware\CorsMiddleware([
+    "origin.server" => "https://example.com"
+]));
+```
+
+```
+$ curl https://example.com/api \
+    --request POST \
+    --include \
+    --header "Origin: https://example.com"
+
+HTTP/1.1 200 OK
+```
+
 ## Testing
 
 You can run tests either manually or automatically on every code change. Automatic tests require [entr](http://entrproject.org/) to work.

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -41,6 +41,7 @@ final class CorsMiddleware implements MiddlewareInterface
         "headers.allow" => [],
         "headers.expose" => [],
         "credentials" => false,
+        "origin.server" => null,
         "cache" => 0,
         "error" => null
     ];
@@ -151,6 +152,10 @@ final class CorsMiddleware implements MiddlewareInterface
 
         $settings->setRequestCredentialsSupported($this->options["credentials"]);
 
+        if (is_string($this->options["origin.server"])) {
+            $settings->setServerOrigin($this->options["origin.server"]);
+        }
+
         $settings->setPreFlightCacheMaxAge($this->options["cache"]);
 
         return $settings;
@@ -198,6 +203,14 @@ final class CorsMiddleware implements MiddlewareInterface
     private function credentials(bool $credentials): void
     {
         $this->options["credentials"] = $credentials;
+    }
+
+    /**
+     * Set the server origin.
+     */
+    private function originServer(?string $origin): void
+    {
+        $this->options["origin.server"] = $origin;
     }
 
     /**

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -274,6 +274,28 @@ class CorsTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testShouldReturn200WithNoCorsHeaders()
+    {
+        $request = (new ServerRequestFactory)
+            ->createServerRequest("GET", "https://example.com/api")
+            ->withHeader("Origin", "https://example.com");
+
+        $response = (new ResponseFactory)->createResponse();
+        $cors = new CorsMiddleware([
+            "origin" => [],
+            "origin.server" => "https://example.com"
+        ]);
+
+        $next = function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write("Foo");
+            return $response;
+        };
+
+        $response = $cors($request, $response, $next);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEmpty($response->getHeaderLine("Access-Control-Allow-Origin"));
+    }
+
     public function testShouldCallError()
     {
         $request = (new ServerRequestFactory)


### PR DESCRIPTION
This option allows the user to explicitly specify the origin of the server.  It is useful in case a same-origin request contains an unnecessary `Origin` header and is blocked because it gets interpreted
as a cross-origin request.

Fixes #22.

Edit: Fix typo.