### PR TITLE
Send all Access-Control-Expose-Headers values in one header (fixes #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## [1.0.1](https://github.com/tuupola/cors-middleware/compare/1.0.0...1.0.1) - unreleased
+### Changed
+- Send multiple `Access-Control-Expose-Headers` values in one header ([#40](https://github.com/tuupola/cors-middleware/issues/40), [#42](https://github.com/tuupola/cors-middleware/pull/42)).
+
 ## [1.0.0](https://github.com/tuupola/cors-middleware/compare/0.9.4...1.0.0) - 2019-06-04
 ### Changed
 - `tuupola/callable-handler:^1.0` is now minimum requirement.

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -38,6 +38,7 @@ namespace Tuupola\Middleware;
 use Closure;
 use Neomerx\Cors\Analyzer as CorsAnalyzer;
 use Neomerx\Cors\Contracts\AnalysisResultInterface as CorsAnalysisResultInterface;
+use Neomerx\Cors\Contracts\Constants\CorsResponseHeaders;
 use Neomerx\Cors\Strategies\Settings as CorsSettings;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -46,6 +47,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Tuupola\Http\Factory\ResponseFactory;
 use Tuupola\Middleware\DoublePassTrait;
+
 
 final class CorsMiddleware implements MiddlewareInterface
 {
@@ -114,6 +116,8 @@ final class CorsMiddleware implements MiddlewareInterface
                 /* Actual CORS request. */
                 $response = $handler->handle($request);
                 $cors_headers = $cors->getResponseHeaders();
+                $cors_headers = $this->fixHeaders($cors_headers);
+
                 foreach ($cors_headers as $header => $value) {
                     /* Diactoros errors on integer values. */
                     if (false === is_array($value)) {
@@ -181,6 +185,17 @@ final class CorsMiddleware implements MiddlewareInterface
         $settings->setPreFlightCacheMaxAge($this->options["cache"]);
 
         return $settings;
+    }
+
+    /**
+     * Edge cannot handle multiple Access-Control-Expose-Headers headers
+     */
+    private function fixHeaders(array $headers): array{
+        if (isset($headers[CorsResponseHeaders::EXPOSE_HEADERS])) {
+            $headers[CorsResponseHeaders::EXPOSE_HEADERS] =
+                implode(', ', $headers[CorsResponseHeaders::EXPOSE_HEADERS]);
+        }
+        return $headers;
     }
 
     /**

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -190,10 +190,11 @@ final class CorsMiddleware implements MiddlewareInterface
     /**
      * Edge cannot handle multiple Access-Control-Expose-Headers headers
      */
-    private function fixHeaders(array $headers): array{
+    private function fixHeaders(array $headers): array
+    {
         if (isset($headers[CorsResponseHeaders::EXPOSE_HEADERS])) {
             $headers[CorsResponseHeaders::EXPOSE_HEADERS] =
-                implode(', ', $headers[CorsResponseHeaders::EXPOSE_HEADERS]);
+                implode(", ", $headers[CorsResponseHeaders::EXPOSE_HEADERS]);
         }
         return $headers;
     }

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -48,7 +48,6 @@ use Psr\Log\LoggerInterface;
 use Tuupola\Http\Factory\ResponseFactory;
 use Tuupola\Middleware\DoublePassTrait;
 
-
 final class CorsMiddleware implements MiddlewareInterface
 {
     use DoublePassTrait;

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -93,7 +93,7 @@ class CorsTest extends TestCase
         $this->assertEquals("http://www.example.com", $response->getHeaderLine("Access-Control-Allow-Origin"));
         $this->assertEquals("true", $response->getHeaderLine("Access-Control-Allow-Credentials"));
         $this->assertEquals("Origin", $response->getHeaderLine("Vary"));
-        $this->assertEquals("Authorization,Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
+        $this->assertEquals("Authorization, Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
     }
 
     public function testShouldReturn401WithWrongOrigin()
@@ -522,7 +522,7 @@ class CorsTest extends TestCase
         $this->assertEquals("http://www.example.com", $response->getHeaderLine("Access-Control-Allow-Origin"));
         $this->assertEquals("true", $response->getHeaderLine("Access-Control-Allow-Credentials"));
         $this->assertEquals("Origin", $response->getHeaderLine("Vary"));
-        $this->assertEquals("Authorization,Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
+        $this->assertEquals("Authorization, Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
         $this->assertEquals("Success", $response->getBody());
     }
 }


### PR DESCRIPTION
Apparently Microsoft Edge [cannot handle](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12046299/) multiple headers. With the following code:

```php
$app->add(new Tuupola\Middleware\CorsMiddleware([
    "headers.expose" => ["Content-Length", "Etag", "X-Foo"],
]));
```

Headers before this PR:

```
Access-Control-Expose-Headers: Content-Length
Access-Control-Expose-Headers: Etag
Access-Control-Expose-Headers: X-Foo
```

After this PR:

```
Access-Control-Expose-Headers: Content-Length, Etag, X-Foo
```