### PR TITLE
Concatenate exposed headers with comma only (see #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## [1.1.1](https://github.com/tuupola/cors-middleware/compare/1.1.0...master) - unreleased
+### Changed
+- Concatenate `Access-Control-Expose-Headers` values with comma instead of comma and space ([#44](https://github.com/tuupola/cors-middleware/pull/44)). Edge has issues with spaces.
+
 ## [1.1.0](https://github.com/tuupola/cors-middleware/compare/1.0.0...1.1.0) - 2019-10-08
 ### Changed
 - Send multiple `Access-Control-Expose-Headers` values in one header ([#40](https://github.com/tuupola/cors-middleware/issues/40), [#42](https://github.com/tuupola/cors-middleware/pull/42)).

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
 
 Copyright (c) 2016-2019 Mika Tuupola
@@ -32,6 +30,8 @@ SOFTWARE.
  * @see       https://www.w3.org/TR/cors/
  * @license   https://www.opensource.org/licenses/mit-license.php
  */
+
+declare(strict_types=1);
 
 namespace Tuupola\Middleware;
 

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -193,7 +193,7 @@ final class CorsMiddleware implements MiddlewareInterface
     {
         if (isset($headers[CorsResponseHeaders::EXPOSE_HEADERS])) {
             $headers[CorsResponseHeaders::EXPOSE_HEADERS] =
-                implode(", ", $headers[CorsResponseHeaders::EXPOSE_HEADERS]);
+                implode(",", $headers[CorsResponseHeaders::EXPOSE_HEADERS]);
         }
         return $headers;
     }

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -93,7 +93,7 @@ class CorsTest extends TestCase
         $this->assertEquals("http://www.example.com", $response->getHeaderLine("Access-Control-Allow-Origin"));
         $this->assertEquals("true", $response->getHeaderLine("Access-Control-Allow-Credentials"));
         $this->assertEquals("Origin", $response->getHeaderLine("Vary"));
-        $this->assertEquals("Authorization, Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
+        $this->assertEquals("Authorization,Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
     }
 
     public function testShouldReturn401WithWrongOrigin()
@@ -522,7 +522,7 @@ class CorsTest extends TestCase
         $this->assertEquals("http://www.example.com", $response->getHeaderLine("Access-Control-Allow-Origin"));
         $this->assertEquals("true", $response->getHeaderLine("Access-Control-Allow-Credentials"));
         $this->assertEquals("Origin", $response->getHeaderLine("Vary"));
-        $this->assertEquals("Authorization, Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
+        $this->assertEquals("Authorization,Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
         $this->assertEquals("Success", $response->getBody());
     }
 }


### PR DESCRIPTION
Apparently Edge cannot handle spaces between header values either.
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12046299/

With example code:

```php
$app->add(new Tuupola\Middleware\CorsMiddleware([
    "headers.expose" => ["content-length", "etag", "x-foo"],
]));
```

Current behaviour (1.1.0): 

```
$ curl --include http://0.0.0.0:8080  \
       --request PUT \
       --include \
       --header "Origin: http://www.example.com"

HTTP/1.1 200 OK
Access-Control-Allow-Origin: http://www.example.com
Vary: Origin
Access-Control-Expose-Headers: content-length, etag, x-foo
```

After applying this PR:

```
$ curl --include http://0.0.0.0:8080  \
       --request PUT \
       --include \
       --header "Origin: http://www.example.com"

HTTP/1.1 200 OK
Access-Control-Allow-Origin: http://www.example.com
Vary: Origin
Access-Control-Expose-Headers: content-length,etag,x-foo
```