### PR TITLE
Add support for wildcard origins (fixes #14)

### DIFF
--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -39,14 +39,13 @@ use Closure;
 use Neomerx\Cors\Analyzer as CorsAnalyzer;
 use Neomerx\Cors\Contracts\AnalysisResultInterface as CorsAnalysisResultInterface;
 use Neomerx\Cors\Contracts\Constants\CorsResponseHeaders;
-use Neomerx\Cors\Strategies\Settings as CorsSettings;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Tuupola\Http\Factory\ResponseFactory;
-use Tuupola\Middleware\DoublePassTrait;
+use Tuupola\Middleware\Settings as CorsSettings;
 
 final class CorsMiddleware implements MiddlewareInterface
 {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tuupola\Middleware;
+
+use Neomerx\Cors\Contracts\Http\ParsedUrlInterface;
+use Neomerx\Cors\Strategies\Settings as BaseSettings;
+
+class Settings extends BaseSettings
+{
+    public function isRequestOriginAllowed(ParsedUrlInterface $requestOrigin): bool
+    {
+        $isAllowed = parent::isRequestOriginAllowed($requestOrigin);
+
+        if (!$isAllowed) {
+            $isAllowed = $this->wildcardOriginAllowed($requestOrigin->getOrigin());
+        }
+
+        return $isAllowed;
+    }
+
+    private function wildcardOriginAllowed(string $origin): bool
+    {
+        foreach ($this->settings[self::KEY_ALLOWED_ORIGINS] as $allowedOrigin => $value) {
+            if (fnmatch($allowedOrigin, $origin)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -44,7 +44,6 @@ use Tuupola\Http\Factory\UriFactory;
 
 class CorsTest extends TestCase
 {
-
     public function testShouldBeTrue()
     {
         $this->assertTrue(true);

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -68,6 +68,37 @@ class CorsTest extends TestCase
         //$this->assertEquals("", $response->getBody());
     }
 
+    public function testShouldAcceptWildcardSettings()
+    {
+        $request = (new ServerRequestFactory())
+            ->createServerRequest("POST", "https://example.com/api")
+            ->withHeader("Origin", "https://subdomain.example.com");
+
+        $response = (new ResponseFactory())->createResponse();
+        $cors = new CorsMiddleware([
+            "origin" => [
+                '*.example.com',
+            ],
+            "methods" => ["GET", "POST", "PUT", "PATCH", "DELETE"],
+            "headers.allow" => ["Authorization", "If-Match", "If-Unmodified-Since"],
+            "headers.expose" => ["Authorization", "Etag"],
+            "credentials" => true,
+            "cache" => 86400,
+        ]);
+
+        $next = function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write("Foo");
+            return $response;
+        };
+
+        $response = $cors($request, $response, $next);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("https://subdomain.example.com", $response->getHeaderLine("Access-Control-Allow-Origin"));
+        $this->assertEquals("true", $response->getHeaderLine("Access-Control-Allow-Credentials"));
+        $this->assertEquals("Origin", $response->getHeaderLine("Vary"));
+        $this->assertEquals("Authorization,Etag", $response->getHeaderLine("Access-Control-Expose-Headers"));
+    }
+
     public function testShouldHaveCorsHeaders()
     {
         $request = (new ServerRequestFactory())

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tuupola\Middleware;
+
+use Neomerx\Cors\Http\ParsedUrl;
+use PHPUnit\Framework\TestCase;
+
+class SettingsTest extends TestCase
+{
+    /**
+     * @var Settings
+     */
+    private $testObject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testObject = new Settings();
+    }
+
+    /**
+     * @dataProvider requestOriginDataProvider
+     */
+    public function testWildcardOrigin(string $origin, array $allowedOrigins, bool $expected): void
+    {
+        $requestOriginMock = $this->createMock(ParsedUrl::class);
+        $requestOriginMock->method('getOrigin')
+            ->willReturn($origin);
+
+        $this->testObject->setRequestAllowedOrigins($allowedOrigins);
+        $result = $this->testObject->isRequestOriginAllowed($requestOriginMock);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function requestOriginDataProvider(): iterable
+    {
+        // Allow subdomain
+        $origin = 'http://www.example.com';
+        $allowedOrigins = [
+            'http://www.example.com' => true,
+        ];
+        yield [$origin, $allowedOrigins, true];
+
+        // Disallow wrong Subdomain
+        $origin = 'http://ws.example.com';
+        $allowedOrigins = [
+            'http://www.example.com' => true,
+        ];
+        yield [$origin, $allowedOrigins, false];
+
+        // Allow All
+        $origin = 'http://ws.example.com';
+        $allowedOrigins = ['*' => true];
+        yield [$origin, $allowedOrigins, true];
+
+        // Allow Subdomain Wildcard
+        $origin = 'http://ws.example.com';
+        $allowedOrigins = ['http://*.example.com' => true];
+        yield [$origin, $allowedOrigins, true];
+
+        // Allow Without Protocol
+        $origin = 'http://ws.example.com';
+        $allowedOrigins = ['*.example.com' => true];
+        yield [$origin, $allowedOrigins, true];
+
+        // Allow Double Subdomain for Wildcard
+        $origin = 'http://a.b.example.com';
+        $allowedOrigins = ['*.example.com' => true];
+        yield [$origin, $allowedOrigins, true];
+
+        // Don't fall for incorrect position
+        $origin = 'http://a.example.com.evil.com';
+        $allowedOrigins = ['*.example.com' => true];
+        yield [$origin, $allowedOrigins, false];
+
+        // Allow Subdomain in the middle
+        $origin = 'a.b.example.com';
+        $allowedOrigins = ['a.*.example.com' => true];
+        yield [$origin, $allowedOrigins, true];
+
+        // Disallow wrong Subdomain
+        $origin = 'b.bc.example.com';
+        $allowedOrigins = ['a.*.example.com' => true];
+        yield [$origin, $allowedOrigins, false];
+
+        // Correctly handle dots in allowed
+        $origin = 'exampleXcom';
+        $allowedOrigins = ['example.com' => true];
+        yield [$origin, $allowedOrigins, false];
+
+        // Allow subdomain
+        $origin = 'test.example.com';
+        $allowedOrigins = ['*example*' => true];
+        yield [$origin, $allowedOrigins, true];
+
+        // Allow subdomain and domain with one rule
+        $origin = 'test.example.com';
+        $allowedOrigins = ['*example*' => true];
+        yield [$origin, $allowedOrigins, true];
+    }
+}

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -26,7 +26,7 @@ class SettingsTest extends TestCase
     public function testIsRequestOriginAllowed(string $origin, array $allowedOrigins, bool $expected): void
     {
         $requestOriginMock = $this->createMock(ParsedUrl::class);
-        $requestOriginMock->method('getOrigin')
+        $requestOriginMock->method("getOrigin")
             ->willReturn($origin);
 
         $this->testObject->setRequestAllowedOrigins($allowedOrigins);
@@ -38,58 +38,58 @@ class SettingsTest extends TestCase
     public function wildcardOriginDataProvider(): iterable
     {
         // Allow subdomain without wildcard
-        $origin = 'https://www.example.com';
-        $allowedOrigins = ['https://www.example.com' => true];
+        $origin = "https://www.example.com";
+        $allowedOrigins = ["https://www.example.com" => true];
         yield [$origin, $allowedOrigins, true];
 
         // Disallow wrong subdomain
-        $origin = 'https://ws.example.com';
-        $allowedOrigins = ['https://www.example.com' => true];
+        $origin = "https://ws.example.com";
+        $allowedOrigins = ["https://www.example.com" => true];
         yield [$origin, $allowedOrigins, false];
 
         // Allow all
-        $origin = 'https://ws.example.com';
-        $allowedOrigins = ['*' => true];
+        $origin = "https://ws.example.com";
+        $allowedOrigins = ["*" => true];
         yield [$origin, $allowedOrigins, true];
 
         // Allow subdomain wildcard
-        $origin = 'https://ws.example.com';
-        $allowedOrigins = ['https://*.example.com' => true];
+        $origin = "https://ws.example.com";
+        $allowedOrigins = ["https://*.example.com" => true];
         yield [$origin, $allowedOrigins, true];
 
         // Allow without specifying protocol
-        $origin = 'https://ws.example.com';
-        $allowedOrigins = ['*.example.com' => true];
+        $origin = "https://ws.example.com";
+        $allowedOrigins = ["*.example.com" => true];
         yield [$origin, $allowedOrigins, true];
 
         // Allow double subdomain for wildcard
-        $origin = 'https://a.b.example.com';
-        $allowedOrigins = ['*.example.com' => true];
+        $origin = "https://a.b.example.com";
+        $allowedOrigins = ["*.example.com" => true];
         yield [$origin, $allowedOrigins, true];
 
         // Disallow for incorrect domain wildcard
-        $origin = 'https://a.example.com.evil.com';
-        $allowedOrigins = ['*.example.com' => true];
+        $origin = "https://a.example.com.evil.com";
+        $allowedOrigins = ["*.example.com" => true];
         yield [$origin, $allowedOrigins, false];
 
         // Allow subdomain in the middle
-        $origin = 'a.b.example.com';
-        $allowedOrigins = ['a.*.example.com' => true];
+        $origin = "a.b.example.com";
+        $allowedOrigins = ["a.*.example.com" => true];
         yield [$origin, $allowedOrigins, true];
 
         // Disallow wrong subdomain
-        $origin = 'b.bc.example.com';
-        $allowedOrigins = ['a.*.example.com' => true];
+        $origin = "b.bc.example.com";
+        $allowedOrigins = ["a.*.example.com" => true];
         yield [$origin, $allowedOrigins, false];
 
         // Correctly handle dots
-        $origin = 'exampleXcom';
-        $allowedOrigins = ['example.com' => true];
+        $origin = "exampleXcom";
+        $allowedOrigins = ["example.com" => true];
         yield [$origin, $allowedOrigins, false];
 
         // Allow subdomain and domain with one rule
-        $origin = 'test.example.com';
-        $allowedOrigins = ['*example*' => true];
+        $origin = "test.example.com";
+        $allowedOrigins = ["*example*" => true];
         yield [$origin, $allowedOrigins, true];
     }
 }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -21,9 +21,9 @@ class SettingsTest extends TestCase
     }
 
     /**
-     * @dataProvider requestOriginDataProvider
+     * @dataProvider wildcardOriginDataProvider
      */
-    public function testWildcardOrigin(string $origin, array $allowedOrigins, bool $expected): void
+    public function testIsRequestOriginAllowed(string $origin, array $allowedOrigins, bool $expected): void
     {
         $requestOriginMock = $this->createMock(ParsedUrl::class);
         $requestOriginMock->method('getOrigin')
@@ -35,66 +35,61 @@ class SettingsTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function requestOriginDataProvider(): iterable
+    public function wildcardOriginDataProvider(): iterable
     {
-        // Allow subdomain
-        $origin = 'http://www.example.com';
+        // Allow subdomain without wildcard
+        $origin = 'https://www.example.com';
         $allowedOrigins = [
-            'http://www.example.com' => true,
+            'https://www.example.com' => true,
         ];
         yield [$origin, $allowedOrigins, true];
 
-        // Disallow wrong Subdomain
-        $origin = 'http://ws.example.com';
+        // Disallow wrong subdomain
+        $origin = 'https://ws.example.com';
         $allowedOrigins = [
-            'http://www.example.com' => true,
+            'https://www.example.com' => true,
         ];
         yield [$origin, $allowedOrigins, false];
 
-        // Allow All
-        $origin = 'http://ws.example.com';
+        // Allow all
+        $origin = 'https://ws.example.com';
         $allowedOrigins = ['*' => true];
         yield [$origin, $allowedOrigins, true];
 
-        // Allow Subdomain Wildcard
-        $origin = 'http://ws.example.com';
-        $allowedOrigins = ['http://*.example.com' => true];
+        // Allow subdomain wildcard
+        $origin = 'https://ws.example.com';
+        $allowedOrigins = ['https://*.example.com' => true];
         yield [$origin, $allowedOrigins, true];
 
-        // Allow Without Protocol
-        $origin = 'http://ws.example.com';
+        // Allow without specifying protocol
+        $origin = 'https://ws.example.com';
         $allowedOrigins = ['*.example.com' => true];
         yield [$origin, $allowedOrigins, true];
 
-        // Allow Double Subdomain for Wildcard
-        $origin = 'http://a.b.example.com';
+        // Allow double subdomain for wildcard
+        $origin = 'https://a.b.example.com';
         $allowedOrigins = ['*.example.com' => true];
         yield [$origin, $allowedOrigins, true];
 
-        // Don't fall for incorrect position
-        $origin = 'http://a.example.com.evil.com';
+        // Disallow for incorrect domain wildcard
+        $origin = 'https://a.example.com.evil.com';
         $allowedOrigins = ['*.example.com' => true];
         yield [$origin, $allowedOrigins, false];
 
-        // Allow Subdomain in the middle
+        // Allow subdomain in the middle
         $origin = 'a.b.example.com';
         $allowedOrigins = ['a.*.example.com' => true];
         yield [$origin, $allowedOrigins, true];
 
-        // Disallow wrong Subdomain
+        // Disallow wrong subdomain
         $origin = 'b.bc.example.com';
         $allowedOrigins = ['a.*.example.com' => true];
         yield [$origin, $allowedOrigins, false];
 
-        // Correctly handle dots in allowed
+        // Correctly handle dots
         $origin = 'exampleXcom';
         $allowedOrigins = ['example.com' => true];
         yield [$origin, $allowedOrigins, false];
-
-        // Allow subdomain
-        $origin = 'test.example.com';
-        $allowedOrigins = ['*example*' => true];
-        yield [$origin, $allowedOrigins, true];
 
         // Allow subdomain and domain with one rule
         $origin = 'test.example.com';

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -39,16 +39,12 @@ class SettingsTest extends TestCase
     {
         // Allow subdomain without wildcard
         $origin = 'https://www.example.com';
-        $allowedOrigins = [
-            'https://www.example.com' => true,
-        ];
+        $allowedOrigins = ['https://www.example.com' => true];
         yield [$origin, $allowedOrigins, true];
 
         // Disallow wrong subdomain
         $origin = 'https://ws.example.com';
-        $allowedOrigins = [
-            'https://www.example.com' => true,
-        ];
+        $allowedOrigins = ['https://www.example.com' => true];
         yield [$origin, $allowedOrigins, false];
 
         // Allow all


### PR DESCRIPTION
This PR is related to #14 and allows using wildcard configuration for allowed origins.

Based on your comment https://github.com/tuupola/cors-middleware/issues/14#issuecomment-607736091, I decided to add Settings class which extends original `Neomerx\Cors\Strategies\Settings` and adds some extra checks as proposed multiple times in #14.