### PR TITLE
Update psr log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.1|^8.0",
-        "mehrkanal/cors-psr7": "dev-master",
+        "neomerx/cors-psr7": "dev-master#14a45be5d1722f8092a817236428d6f4cb3851d8",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0",
         "tuupola/callable-handler": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.1|^8.0",
-        "neomerx/cors-psr7": "^1.0.4",
+        "mehrkanal/cors-psr7": "dev-master",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0",
         "tuupola/callable-handler": "^1.0",


### PR DESCRIPTION
neomerx/cors-psr7 have not been updated for a long time, despite there is a PR since 7th of January 2022. Therefore it is better to have composer linked directly to commit for pcr/log, so it would be possible to use tuupola/cors-middleware with commit or as a separate package.