### PR TITLE
Add rector as dev dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,15 @@
 help:
 	@echo ""
 	@echo "Available tasks:"
-	@echo "    test    Run all tests and generate coverage"
-	@echo "    watch   Run all tests and coverage when a source file is upaded"
-	@echo "    lint    Run only linter and code style checker"
-	@echo "    unit    Run unit tests and generate coverage"
-	@echo "    unit    Run static analysis"
-	@echo "    vendor  Install dependencies"
-	@echo "    clean   Remove vendor and composer.lock"
+	@echo "    test            Run all tests and generate coverage"
+	@echo "    watch           Run all tests and coverage when a source file is upaded"
+	@echo "    lint            Run only linter and code style checker"
+	@echo "    unit            Run unit tests and generate coverage"
+	@echo "    rector-dry-run  Run rector code migrations and show the proposed changes"
+	@echo "    rector          Run rector code migrations and apply the proposed changes"
+	@echo "    unit            Run static analysis"
+	@echo "    vendor          Install dependencies"
+	@echo "    clean           Remove vendor and composer.lock"
 	@echo ""
 
 vendor: $(wildcard composer.lock)
@@ -25,6 +27,12 @@ unit: vendor
 static: vendor
 	vendor/bin/phpstan analyse src --level max
 
+rector-dry-run: vendor
+	vendor/bin/rector process --dry-run
+
+rector: vendor
+	vendor/bin/rector process
+
 watch: vendor
 	find . -name "*.php" -not -path "./vendor/*" -o -name "*.json" -not -path "./vendor/*" | entr -c make test
 
@@ -36,4 +44,4 @@ clean:
 	rm .phplint-cache
 	rm -rf report
 
-.PHONY: help lint unit watch test clean
+.PHONY: help lint unit watch test clean rector rector-dry-run

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-strict-rules": "^1.4",
         "phpunit/phpunit": "^7.0|^8.0|^9.0",
+        "rector/rector": "^0.14.0",
         "squizlabs/php_codesniffer": "^3.5"
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
+use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    // path to phpstan config
+    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
+
+    // add src and tests folder as refactoring targets
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    // define sets of rules
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_72,
+        SetList::CODING_STYLE,
+        SetList::DEAD_CODE,
+        SetList::CODE_QUALITY,
+    ]);
+
+    // skip closure transformation
+    $rectorConfig->skip([
+        StaticClosureRector::class,
+        SimplifyIfElseToTernaryRector::class,
+    ]);
+
+    $rectorConfig->importNames();
+};

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -128,6 +128,7 @@ final class CorsMiddleware implements MiddlewareInterface
         if ($this->logger !== null) {
             $analyzer->setLogger($this->logger);
         }
+
         $cors = $analyzer->analyze($request);
 
         switch ($cors->getRequestType()) {
@@ -150,11 +151,13 @@ final class CorsMiddleware implements MiddlewareInterface
                 $cors_headers = $cors->getResponseHeaders();
                 foreach ($cors_headers as $header => $value) {
                     /* Diactoros errors on integer values. */
-                    if (false === is_array($value)) {
+                    if (!is_array($value)) {
                         $value = (string)$value;
                     }
+
                     $response = $response->withHeader($header, $value);
                 }
+
                 return $response->withStatus(200);
             case CorsAnalysisResultInterface::TYPE_REQUEST_OUT_OF_CORS_SCOPE:
                 return $handler->handle($request);
@@ -166,11 +169,13 @@ final class CorsMiddleware implements MiddlewareInterface
 
                 foreach ($cors_headers as $header => $value) {
                     /* Diactoros errors on integer values. */
-                    if (false === is_array($value)) {
+                    if (!is_array($value)) {
                         $value = (string)$value;
                     }
+
                     $response = $response->withHeader($header, $value);
                 }
+
                 return $response;
         }
     }
@@ -219,6 +224,7 @@ final class CorsMiddleware implements MiddlewareInterface
         } else {
             $methods = (array) $this->options["methods"];
         }
+
         $methods = array_fill_keys($methods, true);
         $settings->setRequestAllowedMethods($methods);
 
@@ -226,6 +232,7 @@ final class CorsMiddleware implements MiddlewareInterface
 
         /* transform all headers to lowercase */
         $headers = array_change_key_case($headers);
+
         $settings->setRequestAllowedHeaders($headers);
 
         $headers = array_fill_keys($this->options["headers.expose"], true);
@@ -251,6 +258,7 @@ final class CorsMiddleware implements MiddlewareInterface
             $headers[CorsResponseHeaders::EXPOSE_HEADERS] =
                 implode(",", $headers[CorsResponseHeaders::EXPOSE_HEADERS]);
         }
+
         return $headers;
     }
 
@@ -353,6 +361,7 @@ final class CorsMiddleware implements MiddlewareInterface
                 return $handler_response;
             }
         }
+
         return $response;
     }
 }


### PR DESCRIPTION
This adds rector and the results of its initial run (upgrade to php72
codelevel).

The following rules applied:
 * SimplifyBoolIdenticalTrueRector
 * NewlineBeforeNewAssignSetRector
 * NewlineAfterStatementRector
 * CallableThisArrayToAnonymousFunctionRector

Also add Makefile target for rector and a separate target to perform a
dry run.