### PR TITLE
Bump neomerx/cors-psr7 and Perform php8 upgrade

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ["7.2", "7.3", "7.4", "8.0", "8.1"]
+        php-versions: ["8.0", "8.1"]
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
       "sort-packages": true
     },
     "require": {
-        "php": "^7.2|^8.0",
-        "neomerx/cors-psr7": "^2",
+        "php": "^8.0",
+        "neomerx/cors-psr7": "^3.0",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0",
         "tuupola/callable-handler": "^1.0",
@@ -41,7 +41,7 @@
     "require-dev": {
         "equip/dispatch": "^2.0",
         "nyholm/psr7": "^1.5",
-        "overtrue/phplint": "^3.0",
+        "overtrue/phplint": "^4.0",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-strict-rules": "^1.4",
         "phpunit/phpunit": "^7.0|^8.0|^9.0",

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
+use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
 use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
@@ -20,7 +21,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     /* Define sets of rules */
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_72,
+        LevelSetList::UP_TO_PHP_80,
         SetList::CODING_STYLE,
         SetList::DEAD_CODE,
         SetList::CODE_QUALITY,
@@ -30,6 +31,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->skip([
         StaticClosureRector::class,
         SimplifyIfElseToTernaryRector::class,
+        StaticArrowFunctionRector::class,
     ]);
 
     $rectorConfig->importNames();

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -69,8 +69,7 @@ final class CorsMiddleware implements MiddlewareInterface
     /** @var int */
     private const PORT_HTTPS = 443;
 
-    /** @var LoggerInterface|null */
-    private $logger;
+    private ?LoggerInterface $logger = null;
 
     /**
      * @var array{
@@ -85,7 +84,7 @@ final class CorsMiddleware implements MiddlewareInterface
      *  logger: null|LoggerInterface,
      * }
      */
-    private $options = [
+    private array $options = [
         "origin" => ["*"],
         "methods" => ["GET", "POST", "PUT", "PATCH", "DELETE"],
         "headers.allow" => [],
@@ -315,7 +314,7 @@ final class CorsMiddleware implements MiddlewareInterface
      * Set request methods to be allowed.
      * @param callable|array $methods.
      */
-    private function methods($methods): void
+    private function methods(callable|array $methods): void
     {
         if (is_callable($methods)) {
             if ($methods instanceof Closure) {
@@ -324,7 +323,7 @@ final class CorsMiddleware implements MiddlewareInterface
                 $this->options["methods"] = $methods;
             }
         } else {
-            $this->options["methods"] = (array) $methods;
+            $this->options["methods"] = $methods;
         }
     }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -33,7 +33,7 @@ use Neomerx\Cors\Strategies\Settings as BaseSettings;
 class Settings extends BaseSettings
 {
     /** @var array<string> */
-    private $allowedOrigins = [];
+    private array $allowedOrigins = [];
 
     public function setAllowedOrigins(array $origins): BaseSettings
     {

--- a/tests/CorsMiddlewareTest.php
+++ b/tests/CorsMiddlewareTest.php
@@ -213,9 +213,7 @@ class CorsMiddlewareTest extends TestCase
         $response = (new ResponseFactory())->createResponse();
         $cors = new CorsMiddleware([
             "origin" => "*",
-            "methods" => function ($request) {
-                return ["GET", "POST", "DELETE"];
-            },
+            "methods" => fn ($request) => ["GET", "POST", "DELETE"],
             "headers.allow" => ["Authorization", "If-Match", "If-Unmodified-Since"],
             "headers.expose" => ["Authorization", "Etag"],
             "credentials" => true,
@@ -271,9 +269,7 @@ class CorsMiddlewareTest extends TestCase
         $response = (new ResponseFactory())->createResponse();
         $cors = new CorsMiddleware([
             "origin" => ["*"],
-            "methods" => function ($request) {
-                return ["GET", "POST", "DELETE"];
-            },
+            "methods" => fn ($request) => ["GET", "POST", "DELETE"],
             "headers.allow" => ["Authorization", "If-Match", "If-Unmodified-Since"],
             "headers.expose" => ["Authorization", "Etag"],
             "credentials" => true,
@@ -329,9 +325,7 @@ class CorsMiddlewareTest extends TestCase
         $response = (new ResponseFactory())->createResponse();
         $cors = new CorsMiddleware([
             "origin" => ["*"],
-            "methods" => function (ServerRequestInterface $request) {
-                return TestMethodsHandler::methods($request);
-            },
+            "methods" => fn (ServerRequestInterface $request) => TestMethodsHandler::methods($request),
             "headers.allow" => ["Authorization", "If-Match", "If-Unmodified-Since"],
             "headers.expose" => ["Authorization", "Etag"],
             "credentials" => true,
@@ -364,9 +358,7 @@ class CorsMiddlewareTest extends TestCase
             "headers.expose" => ["Authorization", "Etag"],
             "credentials" => true,
             "cache" => 86400,
-            "error" => function ($request, $response, $arguments) {
-                return "ignored";
-            },
+            "error" => fn ($request, $response, $arguments) => "ignored",
         ]);
 
         $next = static function (ServerRequestInterface $request, ResponseInterface $response) {
@@ -443,7 +435,7 @@ class CorsMiddlewareTest extends TestCase
             "logger" => $logger,
             "origin" => ["*"],
             "methods" => function () use (&$interceptedClassName) {
-                $interceptedClassName = get_class($this);
+                $interceptedClassName = $this::class;
 
                 return ["GET"];
             },
@@ -486,7 +478,7 @@ class CorsMiddlewareTest extends TestCase
             "credentials" => true,
             "cache" => 86400,
             "error" => function ($request, $response, $arguments) {
-                $response->getBody()->write(get_class($this));
+                $response->getBody()->write($this::class);
                 return $response;
             },
         ]);
@@ -498,7 +490,7 @@ class CorsMiddlewareTest extends TestCase
 
         $response = $cors($request, $response, $next);
         $this->assertEquals(401, $response->getStatusCode());
-        $this->assertEquals(get_class($cors), $response->getBody());
+        $this->assertEquals($cors::class, $response->getBody());
     }
 
     public function testShouldCallInvokableErrorClass(): void
@@ -550,13 +542,7 @@ class CorsMiddlewareTest extends TestCase
             "headers.expose" => ["Authorization", "Etag"],
             "credentials" => true,
             "cache" => 86400,
-            "error" => function (
-                ServerRequestInterface $request,
-                ResponseInterface $response,
-                array $arguments
-            ): ResponseInterface {
-                return TestErrorHandler::error($request, $response, $arguments);
-            },
+            "error" => fn (ServerRequestInterface $request, ResponseInterface $response, array $arguments): ResponseInterface => TestErrorHandler::error($request, $response, $arguments),
         ]);
 
         $next = static function (ServerRequestInterface $request, ResponseInterface $response) {

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -33,8 +33,7 @@ use PHPUnit\Framework\TestCase;
 
 class SettingsTest extends TestCase
 {
-    /** @var Settings */
-    private $testObject;
+    private Settings $testObject;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Hi there

This updates the neomerx/cors-psr7 dependency to its new major version 3 which only supports php8 and up. So perform the small php8 upgrade, too