### PR TITLE
Use localhost as default origin server (fixes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## [1.4.2](https://github.com/tuupola/cors-middleware/compare/1.4.1...1.4.2) - unreleased
+### Fixed
+- AssertionError if user had `zend.assertions` enabled php.ini ([#75](https://github.com/tuupola/cors-middleware/pull/75), [#76](https://github.com/tuupola/cors-middleware/pull/76)).
+
+
 ## [1.4.1](https://github.com/tuupola/cors-middleware/compare/1.4.0...1.4.1) - 2022-10-07
 ### Fixed
 - PHPStan annotations for the constructor ([#73](https://github.com/tuupola/cors-middleware/pull/73)).

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -266,7 +266,7 @@ final class CorsMiddleware implements MiddlewareInterface
         /* Set defaults */
         $url = [
             "scheme" => "https",
-            "host" => "",
+            "host" => "localhost",
             "port" => self::PORT_HTTPS,
         ];
 


### PR DESCRIPTION
Since the middleware does not enable the the optional [Host header checking](https://github.com/neomerx/cors-psr7/blob/5aa0f845297d0610fbe50d2d70bd8a118bdfa123/src/Strategies/Settings.php#L503-L513), it should be safe to set the origin server to a dummy value.