### PR TITLE
Fix PHP 8.4 "Implicitly marking parameter as nullable is deprecated"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php-versions: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
         dependency-versions: ["highest", "lowest"]
     runs-on: ${{ matrix.operating-system }}
     steps:
@@ -31,3 +31,4 @@ jobs:
         run: make static
       - name: Upload coverage
         uses: codecov/codecov-action@v1
+

--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -378,7 +378,7 @@ final class CorsMiddleware implements MiddlewareInterface
      * Set the PSR-3 logger.
      * @phpstan-ignore method.unused
      */
-    private function logger(LoggerInterface $logger = null): void
+    private function logger(?LoggerInterface $logger = null): void
     {
         $this->logger = $logger;
     }
@@ -389,7 +389,7 @@ final class CorsMiddleware implements MiddlewareInterface
     private function processError(
         ServerRequestInterface $request,
         ResponseInterface $response,
-        array $arguments = null
+        ?array $arguments = null
     ): ResponseInterface {
         if (is_callable($this->options["error"])) {
             $handler_response = $this->options["error"]($request, $response, $arguments);


### PR DESCRIPTION
This PR fixes a deprecated warning on PHP 8.4, and is backwards compatible back to PHP 7.1.

Addresses #91 